### PR TITLE
Allow dependency on time to be 1.2.0.5 instead of 1.2.0.3

### DIFF
--- a/HDBC.cabal
+++ b/HDBC.cabal
@@ -33,7 +33,7 @@ flag time_gte_113
 
 library
   if flag(splitBase)
-    Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.2.0.3, bytestring, containers, old-locale
+    Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.2.0.5, bytestring, containers, old-locale
     if flag(time_gte_113)
       Build-Depends: time>=1.1.3
       CPP-OPTIONS: -DTIME_GT_113


### PR DESCRIPTION
I need to use 1.2.0.5 because it fixes a bug where parseTime was not handling padding properly. This dependency is making cabal choke. 

Thanks!
