### PR TITLE
Fix URLs in cabal file

### DIFF
--- a/HDBC.cabal
+++ b/HDBC.cabal
@@ -3,7 +3,7 @@ Version: 2.3.1.0
 License: BSD3
 Maintainer: Nicolas Wu <nick@well-typed.com>
 Author: John Goerzen
-homepage: https://github.com/jgoerzen/hdbc/wiki
+homepage: https://github.com/hdbc/hdbc/wiki
 Copyright: Copyright (c) 2005-2011 John Goerzen
 license-file: LICENSE
 extra-source-files: LICENSE, Makefile, Memory.txt, README.txt
@@ -20,7 +20,7 @@ Cabal-Version: >=1.8
 
 source-repository head
   type:            git
-  location:        https://github.com/jgoerzen/hdbc.git
+  location:        https://github.com/hdbc/hdbc.git
 
 flag splitBase
   description: Choose the new smaller, split-up base package.


### PR DESCRIPTION
Between this and the GHC 7.4 breakage, we need a new release.
