### PR TITLE
Relax time dependency to allow time 1.3 and 1.4.

### DIFF
--- a/HDBC.cabal
+++ b/HDBC.cabal
@@ -33,7 +33,7 @@ flag time_gte_113
 
 library
   if flag(splitBase)
-    Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.2.0.5, bytestring, containers, old-locale
+    Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.5, bytestring, containers, old-locale
     if flag(time_gte_113)
       Build-Depends: time>=1.1.3
       CPP-OPTIONS: -DTIME_GT_113
@@ -64,7 +64,7 @@ Executable runtests
       Build-Depends: HUnit, QuickCheck (>= 2.0), testpack (>= 2.0)
 
       if flag(splitBase)
-        Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.1.4, bytestring, containers, old-locale
+        Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.5, bytestring, containers, old-locale
         if flag(time_gte_113)
           Build-Depends: time>=1.1.3
           CPP-OPTIONS: -DTIME_GT_113


### PR DESCRIPTION
Tested with GHC 6.12.3, 7.0.3, 7.2.1 and 7.4.0.20111219, and time 1.2, 1.3 and 1.4 (though not in all permutations).
