### PR TITLE
Add wrapper for 'runRaw'

### DIFF
--- a/Database/HDBC/Types.hs
+++ b/Database/HDBC/Types.hs
@@ -199,6 +199,7 @@ instance IConnection ConnWrapper where
     disconnect w = withWConn w disconnect
     commit w = withWConn w commit
     rollback w = withWConn w rollback
+    runRaw w = withWConn w runRaw
     run w = withWConn w run
     prepare w = withWConn w prepare
     clone w = withWConn w (\dbh -> clone dbh >>= return . ConnWrapper)


### PR DESCRIPTION
This fixes a bug I encountered because HDBC-sqlite3 overrides the default method for 'runRaw'.  Without this patch, 'runRaw' on a sqlite3 connection behaves differently depending on if it's inside a 'ConnWrapper' or not.
