### PR TITLE
Time 1.5 compatibility.

### DIFF
--- a/Database/HDBC/Locale.hs
+++ b/Database/HDBC/Locale.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Database.HDBC.Locale
     (
      defaultTimeLocale,
@@ -5,7 +6,12 @@ module Database.HDBC.Locale
     )
 
 where
+
+#ifdef MIN_TIME_15
+import Data.Time.Format (defaultTimeLocale)
+#else
 import System.Locale (defaultTimeLocale)
+#endif
 
 -- | As the semantic of System.Locale.iso8601DateFormat has changed with
 --   old-locale-1.0.0.2 in a non-compatible way, we now define our own

--- a/Database/HDBC/SqlValue.hs
+++ b/Database/HDBC/SqlValue.hs
@@ -17,7 +17,11 @@ import Data.Char(ord,toUpper)
 import Data.Word
 import Data.Int
 import qualified System.Time as ST
-import Data.Time
+import Data.Time ( Day (ModifiedJulianDay), DiffTime, LocalTime, NominalDiffTime, ParseTime
+                 , TimeOfDay, TimeZone, UTCTime, ZonedTime, formatTime, localDay, localTimeOfDay
+                 , parseTime, timeOfDayToTime, timeToTimeOfDay, toModifiedJulianDay, utc
+                 , utcToZonedTime, zonedTimeToLocalTime, zonedTimeToUTC, zonedTimeZone
+                 )
 import Data.Time.Clock.POSIX
 import Database.HDBC.Locale (defaultTimeLocale, iso8601DateFormat)
 import Data.Ratio

--- a/HDBC.cabal
+++ b/HDBC.cabal
@@ -27,10 +27,18 @@ flag splitBase
 flag buildtests
   description: Build the executable to run unit tests
   default: False
+flag minTime15
+  description: Use time 1.5 or higher.
+  default: True
 
 library
   if flag(splitBase)
-    Build-Depends: base>=3 && <5, old-time, time>=1.1.3 && <=1.5, bytestring, containers, old-locale
+    Build-Depends: base>=3 && <5, old-time, bytestring, containers
+    if flag(minTime15)
+      Build-Depends: time >= 1.5 && < 1.6
+      CPP-Options: -DMIN_TIME_15
+    else
+      Build-Depends: time < 1.5, old-locale
   else
     Build-Depends: base<3
   Build-Depends: mtl, convertible >= 1.1.0.0, text, utf8-string
@@ -56,7 +64,11 @@ Executable runtests
       Build-Depends: HUnit, QuickCheck (>= 2.0), testpack (>= 2.0)
 
       if flag(splitBase)
-        Build-Depends: base>=3 && <5, old-time, time>=1.1.3 && <=1.5, bytestring, containers, old-locale
+        Build-Depends: base>=3 && <5, old-time, bytestring, containers
+        if flag(minTime15)
+          Build-Depends: time >= 1.5 && < 1.6
+        else
+          Build-Depends: time < 1.5, old-locale
       else
         Build-Depends: base<3
       Build-Depends: mtl, convertible >= 1.1.0.0, utf8-string, text


### PR DESCRIPTION
I chose to make the import of `Data.Time` use explicit names, since it now exports `iso8601DateFormat`. If you'd rather change it to use `hiding`, let me know.