### PR TITLE
Add finalize function

### DIFF
--- a/Database/HDBC.hs
+++ b/Database/HDBC.hs
@@ -55,7 +55,7 @@ module Database.HDBC
      -- ** Statement Inquires
      describeResult,
      -- ** Miscellaneous
-     finish, originalQuery,
+     finish, finalize, originalQuery,
 
      -- * Exceptions
      SqlError(..),

--- a/Database/HDBC/Statement.hs
+++ b/Database/HDBC/Statement.hs
@@ -51,9 +51,17 @@ data Statement = Statement
 
         This is most useful for non-SELECT statements. -}
      executeMany :: [[SqlValue]] -> IO (),
-                 
-     {- | Abort a query in progress -- usually not needed. -}
+
+     {- | Abort a query in progress -- usually not needed. This allows
+        executing the query once again later with a different parameter set -}
      finish :: IO (),
+
+     {- | Finalizes the statement and immediately frees up any associated resources.
+          Doing anything with a finalized statement will break your program.
+
+          This is mainly intended for optimization to avoid waiting for GC to invoke
+          finalizer on the statement. -}
+     finalize :: IO (),
 
      {- | Fetches one row from the DB.  Returns 'Nothing' if there
         are no more rows.  Will automatically call 'finish' when

--- a/HDBC.cabal
+++ b/HDBC.cabal
@@ -1,5 +1,5 @@
 Name: HDBC
-Version: 2.4.0.0
+Version: 2.5.0.0
 License: BSD3
 Maintainer: Nicolas Wu <nicolas.wu@gmail.com>
 Author: John Goerzen, Nicolas Wu


### PR DESCRIPTION
HDBC currently relies on runtime garbage collector to free resources for statements that are no longer used. Implementations like HDBC-odbc therefore rely on statement finalizers to clean up allocated ODBC statements. While it is the only true safe way of releasing resources, finalizer methods are known to have no guarantees about when exactly they will be ran, except that it will happen before program exits.

SQL queries, on the other hand, often live for rather short time. It seems to me reasonable to add ```finalize``` function to HDBC statements, which could be used to clean up resources and additional allocated memory at known time. This, unfortunately, comes at a cost that no other statement functions should be called after the ```finalize```, but it seems a reasonable price to me.

This pull request implements the proposal. Unfortunately it is a breaking change, that's why I've also bumped version number to 2.5. Hopefully in some reasonable time maintainers of HDBC-* packages will provide implementation for this function, or will use simple ```return ()``` as a quick fix.

I already have the patch for HDBC-odbc that makes use of these changes so at least that package will be HDBC-2.5-ready very soon.