### PR TITLE
Make use of GHC's DEPRECATED pragma

### DIFF
--- a/Database/HDBC/SqlValue.hs
+++ b/Database/HDBC/SqlValue.hs
@@ -218,10 +218,12 @@ data SqlValue = SqlString String
               | SqlUTCTime UTCTime          -- ^ UTC YYYY-MM-DD HH:MM:SS.
               | SqlDiffTime NominalDiffTime -- ^ Calendar diff between seconds.  Rendered as Integer when converted to String, but greater precision may be preserved for other types or to underlying database.
               | SqlPOSIXTime POSIXTime      -- ^ Time as seconds since midnight Jan 1 1970 UTC.  Integer rendering as for 'SqlDiffTime'.
-              | SqlEpochTime Integer      -- ^ DEPRECATED Representation of ClockTime or CalendarTime.  Use SqlPOSIXTime instead.
-              | SqlTimeDiff Integer -- ^ DEPRECATED Representation of TimeDiff.  Use SqlDiffTime instead.
+              | SqlEpochTime Integer        -- ^ Representation of ClockTime or CalendarTime.
+              | SqlTimeDiff Integer         -- ^ Representation of TimeDiff.
               | SqlNull         -- ^ NULL in SQL or Nothing in Haskell.
      deriving (Show, Typeable, Data)
+{-# DEPRECATED SqlEpochTime "Use 'SqlPOSIXTime' instead." #-}
+{-# DEPRECATED SqlTimeDiff "Use 'SqlDiffTime' instead." #-}
 
 instance Eq SqlValue where
     SqlString a == SqlString b = a == b

--- a/Database/HDBC/SqlValue.hs
+++ b/Database/HDBC/SqlValue.hs
@@ -9,6 +9,7 @@ module Database.HDBC.SqlValue
     )
 
 where
+import Data.Data (Data)
 import Data.Dynamic
 import qualified Data.ByteString.UTF8 as BUTF8
 import qualified Data.ByteString as B
@@ -220,7 +221,7 @@ data SqlValue = SqlString String
               | SqlEpochTime Integer      -- ^ DEPRECATED Representation of ClockTime or CalendarTime.  Use SqlPOSIXTime instead.
               | SqlTimeDiff Integer -- ^ DEPRECATED Representation of TimeDiff.  Use SqlDiffTime instead.
               | SqlNull         -- ^ NULL in SQL or Nothing in Haskell.
-     deriving (Show, Typeable)
+     deriving (Show, Typeable, Data)
 
 instance Eq SqlValue where
     SqlString a == SqlString b = a == b


### PR DESCRIPTION
GHC includes a DEPRECATED pragma which makes it warn about use of deprecated symbols.
Additionally, Haddock uses some fancy red markup for the depreciation message.
Thus, use the pragma for the deprecated constructors `SqlEpochTime` and `SqlTimeDiff`.

Note: This commit/PR is based on PR #37, so it includes that commit. If you prefer not to merge PR #37, I can untangle the commits.