### PR TITLE
Remove confusing installation/usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,3 @@ Haskell.
 
 Please see the HDBC [wiki](https://github.com/hdbc/hdbc/wiki) for an
 introduction to HDBC and its various features.
-
-Installation
-------------
-
-You'll need either GHC 6.4.1 or above, or Hugs 2005xx or above.
-
-The steps to install are:
-
-    ghc --make -o setup Setup.lhs
-    ./setup configure
-    ./setup build
-    sudo ./setup install
-
-If you're on Windows, you can omit the leading "./".
-
-Usage
------
-
-To use with hugs, you'll want to use hugs -98.
-
-To use with GHC, you'll want to use -package HDBC in your programs.
-Or, with Cabal, use Build-Depends: HDBC.


### PR DESCRIPTION
When helping someone getting started with Haskell it turned out they were super confused and got stuck with trying to use the `HDBC` package because of the installation instructions not matching their expectations (of using `stack` or `cabal`). These instructions are so outdated that they should be removed.