### PR TITLE
add support for multiple result sets

### DIFF
--- a/Database/HDBC.hs
+++ b/Database/HDBC.hs
@@ -55,7 +55,7 @@ module Database.HDBC
      -- ** Statement Inquires
      describeResult,
      -- ** Miscellaneous
-     finish, originalQuery,
+     finish, originalQuery, nextResultSet,
 
      -- * Exceptions
      SqlError(..),

--- a/Database/HDBC.hs
+++ b/Database/HDBC.hs
@@ -12,7 +12,7 @@ Welcome to HDBC, the Haskell Database Connectivity library.
 Written by John Goerzen, jgoerzen\@complete.org
 -}
 
-module Database.HDBC 
+module Database.HDBC  
     (-- * Introduction
      -- $introduction
 
@@ -71,7 +71,6 @@ module Database.HDBC
      -- * Threading
      -- $threading
     )
-
 where
 import Database.HDBC.Utils(catchSql, handleSql, sqlExceptions,
                            handleSqlError, withTransaction,

--- a/Database/HDBC/Statement.hs
+++ b/Database/HDBC/Statement.hs
@@ -31,7 +31,7 @@ data Statement = Statement
         This function should automatically call finish() to finish the previous
         execution, if necessary.
         -}
-     execute :: [SqlValue] -> IO (Maybe Integer),
+     execute :: [SqlValue] -> IO (Maybe Int),
 
      {- | Execute the statement as-is, without supplying any
         positional parameters.  This is intended for statements for
@@ -99,7 +99,7 @@ data Statement = Statement
  -}
      describeResult :: IO [(String, SqlColDesc)],
      
-     nextResultSet :: IO (Maybe Int)
+     nextResultSet :: IO (Maybe (Maybe Int))
     }
 
 {- | The main HDBC exception object.  As much information as possible

--- a/Database/HDBC/Statement.hs
+++ b/Database/HDBC/Statement.hs
@@ -31,7 +31,7 @@ data Statement = Statement
         This function should automatically call finish() to finish the previous
         execution, if necessary.
         -}
-     execute :: [SqlValue] -> IO Integer,
+     execute :: [SqlValue] -> IO (Maybe Integer),
 
      {- | Execute the statement as-is, without supplying any
         positional parameters.  This is intended for statements for
@@ -116,9 +116,5 @@ data SqlError = SqlError {seState :: String,
 #if __GLASGOW_HASKELL__ >= 610
 --data SqlException
 instance Exception SqlError where
-{-
-    toException = SomeException
-    fromException (SomeException e) = Just e
-    fromException _ = Nothing
--}
+
 #endif

--- a/Database/HDBC/Statement.hs
+++ b/Database/HDBC/Statement.hs
@@ -97,7 +97,9 @@ data Statement = Statement
           Please see caveats under 'getColumnNames' for information
           on the column name field here.
  -}
-     describeResult :: IO [(String, SqlColDesc)]
+     describeResult :: IO [(String, SqlColDesc)],
+     
+     nextResultSet :: IO (Maybe Int)
     }
 
 {- | The main HDBC exception object.  As much information as possible

--- a/Database/HDBC/Types.hs
+++ b/Database/HDBC/Types.hs
@@ -86,7 +86,7 @@ and vary by database.  So don't do it.
                    of rows modified (see 'execute' for details).
                    The second parameter is a list
                    of replacement values, if any. -}
-                run :: conn -> String -> [SqlValue] -> IO Integer
+                run :: conn -> String -> [SqlValue] -> IO (Maybe Int)
                 {- | Prepares a statement for execution. 
 
                    Question marks in the statement will be replaced by

--- a/Database/HDBC/Utils.hs
+++ b/Database/HDBC/Utils.hs
@@ -74,13 +74,13 @@ handleSqlError action =
     where handler e = fail ("SQL error: " ++ show e)
 
 {- | Like 'run', but take a list of Maybe Strings instead of 'SqlValue's. -}
-sRun :: IConnection conn => conn -> String -> [Maybe String] -> IO Integer
+sRun :: IConnection conn => conn -> String -> [Maybe String] -> IO (Maybe Int)
 sRun conn qry lst =
     run conn qry (map toSql lst)
 
 {- | Like 'execute', but take a list of Maybe Strings instead of
    'SqlValue's. -}
-sExecute :: Statement -> [Maybe String] -> IO (Maybe Integer)
+sExecute :: Statement -> [Maybe String] -> IO (Maybe Int)
 sExecute sth lst = execute sth (map toSql lst)
 
 {- | Like 'executeMany', but take a list of Maybe Strings instead of

--- a/Database/HDBC/Utils.hs
+++ b/Database/HDBC/Utils.hs
@@ -80,7 +80,7 @@ sRun conn qry lst =
 
 {- | Like 'execute', but take a list of Maybe Strings instead of
    'SqlValue's. -}
-sExecute :: Statement -> [Maybe String] -> IO Integer
+sExecute :: Statement -> [Maybe String] -> IO (Maybe Integer)
 sExecute sth lst = execute sth (map toSql lst)
 
 {- | Like 'executeMany', but take a list of Maybe Strings instead of

--- a/HDBC.cabal
+++ b/HDBC.cabal
@@ -1,5 +1,5 @@
 Name: HDBC
-Version: 2.4.0.2
+Version: 2.4.0.3
 License: BSD3
 Maintainer: Nicolas Wu <nicolas.wu@gmail.com>
 Author: John Goerzen, Nicolas Wu


### PR DESCRIPTION
Dear Maintainer,

Can you please add this pull request? This is to support multiple result sets especially for MS SQL Server.
This is needed for other changes that I intend to make to HDBC-odbc as well as adding a streaming api for odbc (which I have already developed).

Thanks so much!
Grant