### PR TITLE
Allow time 1.10, 1.11, 1.12, 1.13 series

### DIFF
--- a/HDBC.cabal
+++ b/HDBC.cabal
@@ -35,7 +35,7 @@ library
   if flag(splitBase)
     Build-Depends: base>=3 && <5, old-time, bytestring, containers
     if flag(minTime15)
-      Build-Depends: time >= 1.5 && < 1.10
+      Build-Depends: time >= 1.5 && < 1.14
       CPP-Options: -DMIN_TIME_15
     else
       Build-Depends: time < 1.5, old-locale


### PR DESCRIPTION
Tested the following configurations:

    cabal build --constraint='time==1.10'
    cabal build --constraint='time==1.12.1'
    cabal build --constraint='time==1.11.1.2'

All built successfully.

A build with 1.13 is not possible since that version was revoked. By including it in the range, we signal to ourselves that we have already tested this configuration, such that next time we bump, we won't need to attempt and fail testing with 1.13.

If this is merged, I will submit an analogue for HDBC-postgresql.
